### PR TITLE
Handle optional uvloop event loop policy

### DIFF
--- a/nettacker/core/lib/http.py
+++ b/nettacker/core/lib/http.py
@@ -10,7 +10,7 @@ import aiohttp
 
 try:
     import uvloop
-except Exception:  # pragma: no cover
+except (ImportError, ModuleNotFoundError):  # pragma: no cover
     uvloop = None
 
 from nettacker.core.lib.base import BaseEngine
@@ -22,9 +22,9 @@ from nettacker.core.utils.common import (
 )
 
 if uvloop is not None:
-    try:  # pragma: no cover
+    try:
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
-    except Exception:
+    except Exception:  # pragma: no cover
         pass
 
 


### PR DESCRIPTION
## Summary
- make uvloop usage optional and fall back to default asyncio loop when uvloop isn't available

## Testing
- `pre-commit run --files nettacker/core/lib/http.py`
- `pytest tests/core/lib/test_user_added_http_headers.py -q -o addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_689f29703604832cad9d8f3cd422c8c0