### PR TITLE
feat: support Python 3.13

### DIFF
--- a/nettacker/core/lib/socket.py
+++ b/nettacker/core/lib/socket.py
@@ -6,11 +6,11 @@ import os
 import re
 import select
 import socket
-import ssl
 import struct
 import time
 
 from nettacker.core.lib.base import BaseEngine, BaseLibrary
+from nettacker.core.lib.ssl import _wrap_socket
 from nettacker.core.utils.common import reverse_and_regex_condition, replace_dependent_response
 
 log = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ def create_tcp_socket(host, port, timeout):
         return None
 
     try:
-        socket_connection = ssl.wrap_socket(socket_connection)
+        socket_connection = _wrap_socket(socket_connection)
         ssl_flag = True
     except Exception:
         socket_connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/nettacker/core/lib/ssl.py
+++ b/nettacker/core/lib/ssl.py
@@ -10,6 +10,18 @@ from nettacker.core.lib.base import BaseEngine, BaseLibrary
 log = logging.getLogger(__name__)
 
 
+def _wrap_socket(connection):
+    """Wrap a socket using an SSLContext for Python 3.13+ compatibility."""
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    try:
+        context.options |= ssl.OP_LEGACY_SERVER_CONNECT
+    except AttributeError:
+        pass
+    return context.wrap_socket(connection)
+
+
 def is_weak_hash_algo(algo):
     algo = algo.lower()
     for unsafe_algo in ("md2", "md4", "md5", "sha1"):
@@ -117,7 +129,7 @@ def create_tcp_socket(host, port, timeout):
         return None
 
     try:
-        socket_connection = ssl.wrap_socket(socket_connection)
+        socket_connection = _wrap_socket(socket_connection)
         ssl_flag = True
     except Exception:
         socket_connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ release_name = "QUIN"
 nettacker = "nettacker.main:run"
 
 [tool.poetry.dependencies]
-python = "^3.9, <3.13"
+python = "^3.9, <3.14"
 aiohttp = "^3.9.5"
 argparse = "^1.4.0"
 asyncio = "^3.4.3"

--- a/tests/core/lib/test_socket.py
+++ b/tests/core/lib/test_socket.py
@@ -141,7 +141,7 @@ def responses():
 
 class TestSocketMethod:
     @patch("socket.socket")
-    @patch("ssl.wrap_socket")
+    @patch("nettacker.core.lib.socket._wrap_socket")
     def test_create_tcp_socket(self, mock_wrap, mock_socket):
         HOST = "example.com"
         PORT = 80

--- a/tests/core/lib/test_ssl.py
+++ b/tests/core/lib/test_ssl.py
@@ -179,7 +179,7 @@ def connection_params():
 
 class TestSslMethod:
     @patch("socket.socket")
-    @patch("ssl.wrap_socket")
+    @patch("nettacker.core.lib.ssl._wrap_socket")
     def test_create_tcp_socket(self, mock_wrap, mock_socket, connection_params):
         create_tcp_socket(
             connection_params["HOST"], connection_params["PORT"], connection_params["TIMEOUT"]
@@ -192,11 +192,18 @@ class TestSslMethod:
         )
         mock_wrap.assert_called_with(socket_instance)
 
+    @patch("ssl.get_server_certificate", side_effect=ssl.SSLError)
     @patch("nettacker.core.lib.ssl.is_weak_cipher_suite")
     @patch("nettacker.core.lib.ssl.is_weak_ssl_version")
     @patch("nettacker.core.lib.ssl.create_tcp_socket")
     def test_ssl_version_and_cipher_scan_secure(
-        self, mock_connection, mock_ssl_check, mock_cipher_check, ssl_library, connection_params
+        self,
+        mock_connection,
+        mock_ssl_check,
+        mock_cipher_check,
+        mock_get_cert,
+        ssl_library,
+        connection_params,
     ):
         mock_connection.return_value = (
             MockConnectionObject(connection_params["HOST"], "TLSv1.3"),
@@ -224,11 +231,18 @@ class TestSslMethod:
 
         assert result == expected
 
+    @patch("ssl.get_server_certificate", side_effect=ssl.SSLError)
     @patch("nettacker.core.lib.ssl.is_weak_cipher_suite")
     @patch("nettacker.core.lib.ssl.is_weak_ssl_version")
     @patch("nettacker.core.lib.ssl.create_tcp_socket")
     def test_ssl_version_and_cipher_scan_weak(
-        self, mock_connection, mock_ssl_check, mock_cipher_check, ssl_library, connection_params
+        self,
+        mock_connection,
+        mock_ssl_check,
+        mock_cipher_check,
+        mock_get_cert,
+        ssl_library,
+        connection_params,
     ):
         mock_connection.return_value = (
             MockConnectionObject(connection_params["HOST"], "TLSv1.1"),


### PR DESCRIPTION
## Summary
- allow Python 3.13 by loosening version requirement
- replace deprecated `ssl.wrap_socket` with SSLContext-based helper
- mock certificate retrieval and update tests for new wrapper
- reuse SSL wrapper helper to avoid duplication across modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9fdf1d3b4832c88cefc8e5a39119a